### PR TITLE
Change to on workflow_call for release-helm-charts

### DIFF
--- a/workflows/release-helm-charts.yml
+++ b/workflows/release-helm-charts.yml
@@ -8,9 +8,7 @@ name: Publish image and tag/release code
 
 # yamllint disable-line rule:truthy
 on:
-  push:
-    branches:
-      - master
+  workflow_call:
 
 jobs:
   version-check:


### PR DESCRIPTION
For a reusable workflow, we want to do on: workflow_call, rather than directly defining the "on" situation. On: push will run for all pushes in the org, but we want this to only run when called from a workflow defined in the individual repo.