### PR TITLE
Use make deps to build dependencies

### DIFF
--- a/.github/workflows/publish-chart-to-ghcr.yml
+++ b/.github/workflows/publish-chart-to-ghcr.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build chart dependencies
         run: |
-          helm dep build ${{ inputs.chart_path }}
+          make deps
 
       - name: Package Helm chart
         run: |


### PR DESCRIPTION
Use 'make deps' to build chart dependencies.  An umbrella chart may include a local sub-chart that includes other sub-charts.  Assume that 'make deps' handles all such corner cases.